### PR TITLE
Adds deploy to digitalocean button

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,0 +1,15 @@
+spec:
+  name: talk
+  region: nyc
+  services:
+  - dockerfile_path: Dockerfile
+    git:
+      branch: master
+      repo_clone_url: https://github.com/vasanthv/talk
+    http_port: 3000
+    instance_count: 1
+    instance_size_slug: basic-xxs
+    name: talk
+    routes:
+    - path: /
+    run_command: npm start

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ http://localhost:3000
 
 **Note:** its recommended to launch without the companion in local environments.
 
+### Deploy to DigitalOcean App Platform
+
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/toast38coza/talk/tree/master)
+
 ### LICENSE
 
 <a href="https://github.com/vasanthv/talk/blob/master/LICENSE">MIT License</a>


### PR DESCRIPTION
Adds a button so that people can easily deploy this app to the DigitalOcean App Platform 

Note: You will need to change the button in the README once you've merged to master to point to the official repo. 

e.g.: on README.md ±line 46, update it to: 

```
[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/vasanthv/talk/tree/master)
```

