### PR TITLE
[talk] - #56 fix display messages

### DIFF
--- a/www/app.html
+++ b/www/app.html
@@ -82,7 +82,7 @@
 				</div>
 
 				<div id="chatWrap" v-if="showChat">
-					<div id="chats">
+					<div id="chats" ref="chatContainer">
 						<div class="chat" v-for="(chat, i) in chats" v-bind:key="i">
 							<span class="name">{{chat.name}}</span>
 							<span class="date light"> &middot; {{formatDate(chat.date)}}</span>

--- a/www/app.js
+++ b/www/app.js
@@ -237,6 +237,7 @@ const App = Vue.createApp({
 			switch (key) {
 				case "chat":
 					this.chats.push(dataMessage);
+					this.$nextTick(this.scrollToBottom);
 					break;
 				default:
 					break;
@@ -250,6 +251,7 @@ const App = Vue.createApp({
 					this.showChat = true;
 					this.hideToolbar = false;
 					this.chats.push(dataMessage);
+					this.$nextTick(this.scrollToBottom);
 					break;
 				case "audioEnabled":
 					document.getElementById(dataMessage.id + "_audioEnabled").className =
@@ -266,6 +268,10 @@ const App = Vue.createApp({
 				default:
 					break;
 			}
+		},
+		scrollToBottom() {
+			const chatContainer = this.$refs.chatContainer;
+			chatContainer.scrollTop = chatContainer.scrollHeight;
 		},
 		formatDate(dateString) {
 			const date = new Date(dateString);


### PR DESCRIPTION
To achieve a chat-like display where the latest messages are shown at the bottom with the scroll bar positioned accordingly, you can use a combination of HTML and JavaScript: 

1. I've added a `ref` attribute to the `div` with the ID `chats`. This will allow us to reference this element in the JavaScript code.

2. In the `scrollToBottom` method, we use the `scrollTop` property to set the scroll position of the container to the `scrollHeight`, which is the total height of the content inside the container.

3. After pushing a new message to the `chats` array, we use `this.$nextTick` to ensure that the DOM has been updated before we call `scrollToBottom`. This prevents any timing issues with the scroll position adjustment.

Now, whenever you pushing a new message, it will automatically scroll to the bottom of the chat container to show the latest messages.
