### PR TITLE
[talk] - further docker image size reduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN npm install
+RUN npm install && \
+    npm cache clean --force && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* /usr/share/doc/*
 
 EXPOSE 3000
 


### PR DESCRIPTION
Before

```bash
REPOSITORY        TAG               IMAGE ID       CREATED         SIZE
talk-talk         latest            9c99e6db1ba9   3 minutes ago   207MB
```

After

```bash
REPOSITORY        TAG               IMAGE ID       CREATED         SIZE
talk-talk         latest            3d15cd139337   6 seconds ago   200MB
```

1. `npm cache clean --force`: This command clears the npm package cache. The npm package cache can accumulate over time as you install various packages. Cleaning the cache helps to remove unnecessary files, which can save space in the final image.

2. `rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* /usr/share/doc/*`: This command removes various temporary and cache files from the system. Let's break down each part:
   - `/tmp/*`: Deletes files from the system's temporary directory. Temporary files can take up space, and removing them is a common practice to keep the image size smaller.
   - `/var/lib/apt/lists/*`: Deletes package lists retrieved during the package installation process. These lists can take up space and are not necessary in the final image.
   - `/var/tmp/*`: Removes temporary files from another temporary directory.
   - `/usr/share/doc/*`: Deletes documentation files for installed packages. While documentation is useful, it's often not required in the final image, especially for production use cases.

By including these commands in your Dockerfile, you're effectively cleaning up various temporary and unnecessary files, which helps in reducing the size of the final Docker image. This can be particularly important in production environments where smaller image sizes contribute to faster deployment times and reduced resource consumption.